### PR TITLE
Store crop info in VOTable parameters. Updated crop docstrings

### DIFF
--- a/vast_post_processing/crop.py
+++ b/vast_post_processing/crop.py
@@ -4,6 +4,8 @@ import astropy.units as u
 import astropy.wcs as wcs
 import matplotlib.pyplot as plt
 
+from vast_post_processing.utils import fitsutils
+
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from astropy.io.votable import parse
@@ -218,8 +220,13 @@ def moc_to_stmoc(moc: mocpy.moc.MOC,
     stmoc : mocpy.moc.STMOC
         The resulting STMOC.
     """
-    start = Time([hdu.header["DATE-BEG"]])
-    end = Time([hdu.header["DATE-END"]])
+    if "DATE-BEG" not in hdu.header.keys or "DATE-END" not in hdu.header.keys:
+        header = fitsutils.update_header_datetimes(hdu.header)
+    else:
+        header = hdu.header
+        
+    start = Time([header["DATE-BEG"]])
+    end = Time([header["DATE-END"]])
 
     stmoc = STMOC.from_spatial_coverages(start, end, [moc])
 

--- a/vast_post_processing/utils/fitsutils.py
+++ b/vast_post_processing/utils/fitsutils.py
@@ -1,0 +1,35 @@
+"""
+Utility functions for handling fits files
+"""
+
+from astropy.time import Time, TimeDelta
+from astropy.io import fits
+
+def update_header_datetimes(header: fits.header.Header):
+    """Take a fits header containing DATE-OBS and DURATION keys and add
+    the other relevant datetime keys.
+    
+    Parameters
+    ----------
+    header: fits.header.Header
+        The header to update
+    """
+
+    if "DATE-OBS" not in header.keys()
+        raise ValueError("DATE-OBS must be in header keys")
+    if "DURATION" not in header.keys()
+        raise ValueError("DURATION must be in header keys")
+
+    obs_start = Time(header["DATE-OBS"])
+    duration = TimeDelta(header["DURATION"], format='sec')
+    obs_end = obs_start + duration
+    
+    header["MJD-OBS"] = obs_start.mjd
+    header["DATE-BEG"] = obs_start.fits
+    header["DATE-END"] = obs_end.fits
+    header["MJD-BEG"] = obs_start.mjd
+    header["MJD-END"] = obs_end.mjd
+    header["TELAPSE"] = duration.sec
+    header["TIMEUNIT"] =  "s"
+    
+    return


### PR DESCRIPTION
Related to #7.

This should have been included in #1.

This also fixes queries from @hansenjiang re: crop.py:
1. Updates instances of size to crop_size
2. Removes reference to vpc
3. Add utils.fitutils.update_header_datetimes which adds in the correct datetime header keys. This should be deployed separately in #3.