### PR TITLE
Fix astrometric offset correction error - corrections applied in the wrong direction, resulting in offsets doubling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Allow users to specify quantisation level [#101](https://github.com/askap-vast/vast-post-processing/pull/101)
 - Added changelog [#106](https://github.com/askap-vast/vast-post-processing/pull/106)
 
 ### Changed
 
 ### Fixed
+
+- Fixed astrometric correction error - corrections were being applied in the wrong direction, resulting in the offset doubling [#104](https://github.com/askap-vast/vast-post-processing/pull/104)
 
 ### Removed
 
@@ -20,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### List of PRs
 
+- [#104](https://github.com/askap-vast/vast-post-processing/pull/104): fix: Fix error in astrometric correction application
+- [#101](https://github.com/askap-vast/vast-post-processing/pull/101): feat: Allow users to specify quantisation level
 - [#106](https://github.com/askap-vast/vast-post-processing/pull/106): docs: Added changelog
 - [#107](https://github.com/askap-vast/vast-post-processing/pull/107): fix: Removed hardcoded newest epoch variable
 

--- a/vast_post_processing/crossmatch.py
+++ b/vast_post_processing/crossmatch.py
@@ -108,9 +108,9 @@ def crossmatch_qtables(
         [col.rstrip("_") for col in xmatch.colnames if col.endswith("_")],
     )
     # compute the separations
-    xmatch["separation"] = xmatch["coord_reference"].separation(xmatch["coord"])
-    xmatch["dra"], xmatch["ddec"] = xmatch["coord_reference"].spherical_offsets_to(
-        xmatch["coord"]
+    xmatch["separation"] = xmatch["coord"].separation(xmatch["coord_reference"])
+    xmatch["dra"], xmatch["ddec"] = xmatch["coord"].spherical_offsets_to(
+        xmatch["coord_reference"]
     )
     xmatch["flux_peak_ratio"] = (
         xmatch["flux_peak"] / xmatch["flux_peak_reference"]


### PR DESCRIPTION
This is probably a residual of the initial version of the post-processing code (from Andrew)

The way astrometric corrections are currently [calculated](https://github.com/askap-vast/vast-post-processing/blob/3f4a4b54d9eac67eb83b1730548832c326126065/vast_post_processing/crossmatch.py#L112) is to estimate the shift from the reference position to the current position, which means this offset has to be subtracted from the current position to get to reference.

But the way they are [applied](https://github.com/askap-vast/vast-post-processing/blob/3f4a4b54d9eac67eb83b1730548832c326126065/vast_post_processing/corrections.py) adds this to the current position instead of subtracting.

The change made here corrects the first step by estimating the offset that needs to be applied to current position to reach the reference position.

