### PR TITLE
Change the flux scaling calculation from peak flux to int flux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Change the flux scale corrections to use integrated rather than peak flux density [#109](https://github.com/askap-vast/vast-post-processing/pull/109)
 - Generalised reference catalogue path [#108](https://github.com/askap-vast/vast-post-processing/pull/108)
 
 ### Fixed
@@ -28,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### List of PRs
 
+- [#109](https://github.com/askap-vast/vast-post-processing/pull/109): feat: Switch flux scale corrections from peak to integrated
 - [#110](https://github.com/askap-vast/vast-post-processing/pull/110/): feat, fix: add reference_catalog arg to catalog class, handle non-existence of reference images
 - [#108](https://github.com/askap-vast/vast-post-processing/pull/108): feat: Generalised reference catalogue path
 - [#104](https://github.com/askap-vast/vast-post-processing/pull/104): fix: Fix error in astrometric correction application

--- a/vast_post_processing/catalogs.py
+++ b/vast_post_processing/catalogs.py
@@ -231,10 +231,10 @@ class Catalog:
             input_format (str, optional): are the component files selavy or aegean generated?.
                 Defaults to "selavy".
             condon (bool, optional): Apply condon corrections. Defaults to True.
-            flux_limit (float, optional): Flux limit to select sources (sources with peak flux
+            flux_limit (float, optional): Flux limit to select sources (sources with integrated flux
                 > this will be selected). Defaults to 0.
             snr_limit (float, optional): SNR limit to select sources (sources with SNR > this
-                will be selected). Defaults to 20.
+                will be selected). SNR is defined as integrated flux over local rms. Defaults to 20.
             nneighbor (float, optional): Distance to nearest neighbor (in arcmin). Sources with
                 neighbors < this will be removed. Defaults to 1.
             apply_flux_limit (bool, optional): Flag to decide to apply flux limit. Defaults to True.
@@ -330,9 +330,9 @@ class Catalog:
         # Add a flux threshold flag
         if self.flux_flag:
             lim = self.flux_lim
-            flux_mask = flux_peak > lim
+            flux_mask = flux_int > lim
             logger.info(
-                f"Filtering {len(sources[~flux_mask])} sources with peak fluxes <= {lim}"
+                f"Filtering {len(sources[~flux_mask])} sources with integrated fluxes <= {lim}"
             )
 
         # Add good psf flag
@@ -347,16 +347,16 @@ class Catalog:
             )
             ps_mask = ps_metric < 1.5
             logger.info(
-                f"Filtering {len(sources[~ps_mask])} sources that are not point sources."
+                f"Filtering {len(sources[~ps_mask])} sources that are not point sources (flux_peak/flux_int<1.5)."
             )
         else:
             ps_mask = np.ones(len(self.table)).astype(bool)
 
         # Add snr flag
-        snr = np.divide(flux_peak, rms, where=rms != 0, out=np.zeros_like(rms))
+        snr = np.divide(flux_int, rms, where=rms != 0, out=np.zeros_like(rms))
         snr_mask = snr > self.snr_lim
         logger.info(
-            f"Filtering {len(sources[~snr_mask])} sources with SNR <= {self.snr_lim}"
+            f"Filtering {len(sources[~snr_mask])} sources with SNR (=flux_int/rms) <= {self.snr_lim}"
         )
 
         # Select distant sources

--- a/vast_post_processing/catalogs.py
+++ b/vast_post_processing/catalogs.py
@@ -33,6 +33,8 @@ SELAVY_COLUMN_UNITS: dict[str, u.Quantity] = {
     "dec_err": u.arcsec,
     "flux_peak": u.mJy / u.beam,
     "flux_peak_err": u.mJy / u.beam,
+    "flux_int": u.mJy / u.beam,
+    "flux_int_err": u.mJy / u.beam,
     "maj_axis": u.arcsec,
     "maj_axis_err": u.arcsec,
     "min_axis": u.arcsec,
@@ -53,6 +55,8 @@ AEGEAN_COLUMN_MAP: dict[str, tuple[str, u.Quantity]] = {
     "err_dec": ("dec_err", u.deg),
     "peak_flux": ("flux_peak", u.Jy / u.beam),
     "err_peak_flux": ("flux_peak_err", u.Jy / u.beam),
+    "int_flux": ("flux_int", u.Jy / u.beam),
+    "err_int_flux": ("flux_int_err", u.Jy / u.beam),
     "a": ("maj_axis", u.arcsec),
     "b": ("min_axis", u.arcsec),
     "pa": ("pos_ang", u.arcsec),
@@ -93,6 +97,7 @@ def read_selavy(catalog_path: Path) -> QTable:
         - `ra_deg_cont` and `dec_deg_cont`: degrees.
         - `ra_err` and `dec_err`: arcseconds.
         - `flux_peak` and `flux_peak_err`: mJy/beam.
+        - `flux_int` and `flux_int_err`: mJy/beam.
         - `maj_axis`, `maj_axis_err`, `min_axis`, `min_axis_err`: arcseconds.
         - `pos_ang` and `pos_ang_err`: degrees.
         - `rms_image`: mJy/beam.
@@ -150,6 +155,7 @@ def read_aegean_csv(catalog_path: Path) -> QTable:
         - `ra` and `dec`: degrees.
         - `err_ra` and `err_dec`: degrees.
         - `peak_flux` and `err_peak_flux`: Jy/beam.
+        - `int_flux` and `err_int_flux`: Jy/beam.
         - `a`, `err_a`, `b`, `err_b`: fitted semi-major and -minor axes in arcseconds.
         - `pa` and `err_pa`: degrees.
         - `local_rms`: Jy/beam.
@@ -326,7 +332,7 @@ class Catalog:
             lim = self.flux_lim
             flux_mask = flux_peak > lim
             logger.info(
-                f"Filtering {len(sources[~flux_mask])} sources with fluxes <= {lim}"
+                f"Filtering {len(sources[~flux_mask])} sources with peak fluxes <= {lim}"
             )
 
         # Add good psf flag

--- a/vast_post_processing/corrections.py
+++ b/vast_post_processing/corrections.py
@@ -218,7 +218,7 @@ def vast_xmatch_qc(
     flux_corr_mult = 1 / ugradient
     flux_corr_add = -1 * uoffset
     logger.info(
-        f"ODR fit parameters: Sp = Sp,ref * {ugradient} + {uoffset} {flux_unit}.",
+        f"ODR fit parameters: Sint = Sint,ref * {ugradient} + {uoffset} {flux_unit}.",
     )
 
     # Write output to csv if requested

--- a/vast_post_processing/corrections.py
+++ b/vast_post_processing/corrections.py
@@ -129,7 +129,7 @@ def vast_xmatch_qc(
     catalog_path = Path(catalog_path).resolve()
 
     # Add beam divisor as we currently only work with peak fluxes
-    flux_unit /= u.beam
+    #flux_unit /= u.beam
 
     # Create Catalog objects for the reference and pre-corrected catalogues
     reference_catalog = Catalog(


### PR DESCRIPTION
To obtain a flux scaling that is more robust against beam size variations in RACS and VAST, correct the flux scale by comparing integrated fluxes (instead of peak fluxes). This correction is still applied to both the peak and integrated flux.